### PR TITLE
Merge multiple dramatic XML inputs per play in site builder staging

### DIFF
--- a/src/ets/application/site_builder_service.py
+++ b/src/ets/application/site_builder_service.py
@@ -8,12 +8,14 @@ from typing import Any
 from uuid import uuid4
 
 from ets.site_builder import BuildResult, build_static_site, load_site_config
+from ets.site_builder.dramatic_merge import DramaticTeiMergeRequest
 
 from .site_builder_models import (
     SiteBuildRequest,
     SiteBuildServiceResult,
     SitePublicationRequest,
 )
+from .merge_dramatic_tei_service import merge_dramatic_tei_files
 
 
 class SiteBuilderService:
@@ -160,14 +162,24 @@ def _normalize_publication_request(
         if not play.documents:
             raise ValueError(f"Invalid publication request: play '{play_slug}' has no dramatic XML files.")
 
-        primary_document = _require_existing_file(play.documents[0].source_path, label=f"dramatic file for play '{play_slug}'")
-        shutil.copy2(primary_document, dramatic_dir / f"{play_slug}.xml")
-        if len(play.documents) > 1:
-            warnings.append(
-                f"Play '{play_slug}' provided {len(play.documents)} dramatic XML files; only the first file is used in current builder scope."
+        dramatic_sources = tuple(
+            _require_existing_file(doc.source_path, label=f"dramatic file for play '{play_slug}'")
+            for doc in play.documents
+        )
+        play_output = dramatic_dir / f"{play_slug}.xml"
+        if len(dramatic_sources) == 1:
+            shutil.copy2(dramatic_sources[0], play_output)
+        else:
+            merge_result = merge_dramatic_tei_files(
+                DramaticTeiMergeRequest(
+                    act_xml_paths=dramatic_sources,
+                    output_path=play_output,
+                )
             )
-            for extra in play.documents[1:]:
-                _require_existing_file(extra.source_path, label=f"dramatic file for play '{play_slug}'")
+            if not merge_result.ok:
+                detail = merge_result.error_detail or "unknown merge error"
+                raise ValueError(f"Invalid publication request: merge failed for play '{play_slug}': {detail}")
+            warnings.extend(merge_result.warnings)
 
         if play.related_notice_slug:
             mapping_pairs.append((play_slug, play.related_notice_slug))

--- a/tests/test_application_site_builder_service.py
+++ b/tests/test_application_site_builder_service.py
@@ -5,6 +5,8 @@ import shutil
 from pathlib import Path
 from uuid import uuid4
 
+from lxml import etree
+
 from ets.application import (
     DramaticDocumentInput,
     DramaticPlayInput,
@@ -23,6 +25,7 @@ from ets.application import (
 
 ROOT = Path(__file__).resolve().parents[1]
 DRAMATIC_FIXTURES = ROOT / "fixtures" / "site_builder" / "minimal" / "dramatic"
+DRAMATIC_MERGE_FIXTURES = ROOT / "fixtures" / "site_builder" / "merge_dramatic"
 MINIMAL_NOTICES = ROOT / "fixtures" / "site_builder" / "minimal" / "notices"
 REALISTIC_NOTICES = ROOT / "fixtures" / "metopes" / "realistic"
 RUNTIME_ROOT = ROOT / "tests" / "_runtime"
@@ -136,8 +139,8 @@ def test_site_builder_service_build_from_publication_request_supports_grouping_o
     andromaque_a1 = dramatic_pool / "andromaque_A1.xml"
     andromaque_a2 = dramatic_pool / "andromaque_A2.xml"
     berenice_a1 = dramatic_pool / "berenice_A1.xml"
-    shutil.copy2(DRAMATIC_FIXTURES / "andromaque.xml", andromaque_a1)
-    shutil.copy2(DRAMATIC_FIXTURES / "andromaque.xml", andromaque_a2)
+    shutil.copy2(DRAMATIC_MERGE_FIXTURES / "andromaque_act1.xml", andromaque_a1)
+    shutil.copy2(DRAMATIC_MERGE_FIXTURES / "andromaque_act2.xml", andromaque_a2)
     shutil.copy2(DRAMATIC_FIXTURES / "berenice.xml", berenice_a1)
 
     logo_file = base / "logo.txt"
@@ -187,11 +190,15 @@ def test_site_builder_service_build_from_publication_request_supports_grouping_o
     assert result.generated_page_relpaths.index("plays/berenice.html") < result.generated_page_relpaths.index(
         "plays/andromaque.html"
     )
-    assert any("only the first file is used" in warning for warning in result.warnings)
+    assert not any("only the first file is used" in warning for warning in result.warnings)
     assert (output_dir / "assets" / "logos" / "logo.txt").exists()
     assert (output_dir / "assets" / "brand" / "palette.txt").exists()
     assert (output_dir / "xml" / "dramatic" / "andromaque.xml").exists()
     assert (output_dir / "xml" / "notices" / "andromaque-notice.xml").exists()
+    merged_xml = (output_dir / "xml" / "dramatic" / "andromaque.xml").read_text(encoding="utf-8")
+    merged_tree = etree.fromstring(merged_xml.encode("utf-8"))
+    act_divisions = merged_tree.xpath("//*[local-name()='body']/*[local-name()='div' and @type='act']")
+    assert len(act_divisions) == 2
 
 
 def test_site_builder_service_build_from_publication_request_fails_cleanly_on_invalid_request() -> None:


### PR DESCRIPTION
### Motivation
- The publication-request normalization staged only `play.documents[0]`, ignoring additional XML files provided for the same play and emitting a warning that only the first file was used.
- The goal was to remove this bottleneck with a minimal, local change that preserves downstream assumptions by producing a single staged TEI per play. 

### Description
- Changed `_normalize_publication_request` in `src/ets/application/site_builder_service.py` to validate all `play.documents` and to either copy a single file unchanged or merge multiple inputs into one staged TEI using the existing merge service (`merge_dramatic_tei_files` + `DramaticTeiMergeRequest`).
- Propagated warnings returned by the merge step and removed the obsolete warning that only the first file is used, while raising a normalization error if the merge fails. 
- Added the required import and wiring to call the merge service and updated the staging path to always produce a single file `dramatic/{play_slug}.xml` to keep the rest of the builder pipeline unchanged. 
- Updated tests in `tests/test_application_site_builder_service.py` to use merge fixtures and to assert that (a) the old warning is absent and (b) the staged TEI for a multi-file play contains both acts; modified files are `src/ets/application/site_builder_service.py` and `tests/test_application_site_builder_service.py`.
- No changes were made to TEI engine internals, collation, extractors, manifest model, XSL/T templates, rendering, CSS, UI, previews, or public signatures.

### Testing
- Ran `pytest -q tests/test_application_site_builder_service.py tests/test_site_builder_dramatic_merge.py` and all tests passed (`12 passed`).
- The updated test validates single-file behavior remains unchanged and multi-file behavior now produces a merged TEI with two act divisions and no "only the first file is used" warning.
- The merge warnings (if any) are now surfaced in the normalization warnings exposed to the caller.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3d08611808333ad441f4e7b021518)