### PR TITLE
Ouverture automatique du site généré dans le navigateur via un serveur HTTP local

### DIFF
--- a/src/ets/ui/tk/main_window.py
+++ b/src/ets/ui/tk/main_window.py
@@ -118,6 +118,7 @@ class MainWindow(ttk.Frame):
         self.state = UIState()
         self._diagnostics_visible = True
         self._preview_server = preview_server or LocalPreviewServer()
+        self._site_preview_server: LocalPreviewServer | None = None
         self._autosave_store = autosave_store or AutosaveStore()
         self._open_browser = open_browser or webbrowser.open_new_tab
         self._autosave_after_id: str | None = None
@@ -1101,9 +1102,29 @@ class MainWindow(ttk.Frame):
                 f"{base_message}\n\nAvertissements:\n{warning_lines}",
                 parent=self.master,
             )
-            return
+        else:
+            messagebox.showinfo("Génération du site", base_message, parent=self.master)
 
-        messagebox.showinfo("Génération du site", base_message, parent=self.master)
+        if result.output_dir is not None:
+            try:
+                self._open_publication_site_preview(result.output_dir)
+            except OSError as exc:
+                messagebox.showwarning(
+                    "Génération du site",
+                    f"Le site a bien été généré, mais l'ouverture automatique a échoué.\n\n{exc}",
+                    parent=self.master,
+                )
+
+    def _open_publication_site_preview(self, output_dir: Path) -> None:
+        resolved_output_dir = output_dir.resolve()
+        if self._site_preview_server is None or self._site_preview_server.root_dir.resolve() != resolved_output_dir:
+            if self._site_preview_server is not None:
+                self._site_preview_server.stop()
+            self._site_preview_server = LocalPreviewServer(root_dir=resolved_output_dir)
+
+        self._site_preview_server.ensure_running()
+        site_url = self._site_preview_server.url_for("index.html")
+        self._open_browser(site_url)
 
     def action_merge_dramatic_tei(self) -> None:
         request = open_dramatic_merge_dialog(self.master)
@@ -1304,4 +1325,6 @@ class MainWindow(ttk.Frame):
         except Exception:
             pass
         self._preview_server.stop()
+        if self._site_preview_server is not None:
+            self._site_preview_server.stop()
         self.master.destroy()

--- a/tests/test_ui_tk.py
+++ b/tests/test_ui_tk.py
@@ -631,7 +631,8 @@ def test_action_merge_dramatic_tei_cancelled_dialog_does_nothing(monkeypatch: py
 def test_action_build_publication_site_success_routes_through_service(monkeypatch: pytest.MonkeyPatch) -> None:
     root = _make_root()
     try:
-        window = MainWindow(root)
+        opened_urls: list[str] = []
+        window = MainWindow(root, open_browser=lambda url: opened_urls.append(url) or True)
         request = SitePublicationRequest(
             identity=SiteIdentityInput(site_title="ETS"),
             output_dir=RUNTIME_DIR,
@@ -664,11 +665,13 @@ def test_action_build_publication_site_success_routes_through_service(monkeypatc
 
         monkeypatch.setattr("ets.ui.tk.main_window.build_site_from_publication_request", _fake_build)
         monkeypatch.setattr("tkinter.messagebox.showinfo", lambda _title, message, **kwargs: messages.append(message))
+        monkeypatch.setattr(window, "_open_publication_site_preview", lambda output_dir: opened_urls.append(str(output_dir)))
 
         window.action_build_publication_site()
 
         assert called == [request]
         assert messages
+        assert opened_urls == [str(RUNTIME_DIR.resolve())]
         assert "Génération du site terminée." in messages[-1]
         assert "Pages générées: 2" in messages[-1]
     finally:
@@ -678,7 +681,8 @@ def test_action_build_publication_site_success_routes_through_service(monkeypatc
 def test_action_build_publication_site_failure_shows_error(monkeypatch: pytest.MonkeyPatch) -> None:
     root = _make_root()
     try:
-        window = MainWindow(root)
+        opened_urls: list[str] = []
+        window = MainWindow(root, open_browser=lambda url: opened_urls.append(url) or True)
         request = SitePublicationRequest(
             identity=SiteIdentityInput(site_title="ETS"),
             output_dir=RUNTIME_DIR,
@@ -703,10 +707,12 @@ def test_action_build_publication_site_failure_shows_error(monkeypatch: pytest.M
             ),
         )
         monkeypatch.setattr("tkinter.messagebox.showerror", lambda _title, message, **kwargs: errors.append(message))
+        monkeypatch.setattr(window, "_open_publication_site_preview", lambda output_dir: opened_urls.append(str(output_dir)))
 
         window.action_build_publication_site()
 
         assert errors
+        assert opened_urls == []
         assert "Site build configuration failed." in errors[-1]
         assert "site_title" in errors[-1]
     finally:
@@ -716,7 +722,8 @@ def test_action_build_publication_site_failure_shows_error(monkeypatch: pytest.M
 def test_action_build_publication_site_surfaces_warnings(monkeypatch: pytest.MonkeyPatch) -> None:
     root = _make_root()
     try:
-        window = MainWindow(root)
+        opened_urls: list[str] = []
+        window = MainWindow(root, open_browser=lambda url: opened_urls.append(url) or True)
         request = SitePublicationRequest(
             identity=SiteIdentityInput(site_title="ETS"),
             output_dir=RUNTIME_DIR,
@@ -749,11 +756,13 @@ def test_action_build_publication_site_surfaces_warnings(monkeypatch: pytest.Mon
 
         monkeypatch.setattr("ets.ui.tk.main_window.build_site_from_publication_request", _fake_build)
         monkeypatch.setattr("tkinter.messagebox.showwarning", lambda _title, message, **kwargs: warnings.append(message))
+        monkeypatch.setattr(window, "_open_publication_site_preview", lambda output_dir: opened_urls.append(str(output_dir)))
 
         window.action_build_publication_site()
 
         assert called == [request]
         assert warnings
+        assert opened_urls == [str(RUNTIME_DIR.resolve())]
         assert "Avertissements" in warnings[-1]
         assert "unknown play slug" in warnings[-1]
     finally:


### PR DESCRIPTION
### Motivation
- Améliorer l’UX du workflow « Site Builder » en ouvrant automatiquement le site statique généré dans le navigateur après la boîte de dialogue de bilan, sans modifier le moteur de génération ni recourir à `file://`.

### Description
- Ajout d’un serveur de preview dédié géré par l’UI et réutilisation de l’infrastructure existante `LocalPreviewServer` pour servir la racine complète `output_dir` en HTTP local et ouvrir `index.html` via le navigateur (pas de `file://`).
- Branché le flux de fin de build dans `MainWindow.action_build_publication_site` de sorte que, après l’affichage du message d’info ou d’avertissement, on appelle `_open_publication_site_preview(result.output_dir)` si le build a réussi.
- Isolation des aperçus : introduction d’un attribut `self._site_preview_server` distinct de l’aperçu HTML existant (`self._preview_server`) et arrêt propre à la fermeture de l’application.
- Fichiers modifiés : `src/ets/ui/tk/main_window.py` (nouvelle méthode `_open_publication_site_preview`, gestion de `self._site_preview_server`, branchement du flux) et `tests/test_ui_tk.py` (ajustements des tests UI ciblés pour vérifier l’ouverture automatique uniquement en cas de succès).

### Testing
- Tentative d’exécution ciblée des tests UI : `pytest -q tests/test_ui_tk.py -k 'build_publication_site'` a été lancée mais la collecte a échoué à cause d’une dépendance d’environnement (`ModuleNotFoundError: No module named 'lxml'`), donc les tests n’ont pas pu s’exécuter ici.
- Vérification de compilation Python des modules modifiés : `python -m compileall src/ets/ui/tk/main_window.py tests/test_ui_tk.py` a réussi.
- Les tests modifiés sont `tests/test_ui_tk.py` (scénarios success / failure / warnings) et doivent réussir lorsque l’environnement de test inclut la dépendance `lxml` (aucune modification des tests en dehors du périmètre UI/application).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3d4fd54c88333a43a1c8e35346469)